### PR TITLE
Correct hero ordering

### DIFF
--- a/components/Dungeon/CombatScene.jsx
+++ b/components/Dungeon/CombatScene.jsx
@@ -3,8 +3,8 @@ import { useGameStore } from '../../state/GameState.jsx';
 import { useCombatLogic } from '../../hooks/useCombatLogic.js';
 import { useTurnSystem } from '../../hooks/useTurnSystem.js';
 
-/* @tweakable Whether to reverse the order of heroes. Set to false for correct order. */
-const reverseHeroOrder = false;
+/* @tweakable Whether to reverse the order of heroes. Set to true for correct order. */
+const reverseHeroOrder = true;
 
 function Character({ char, isActive, onTarget, isTargetable }) {
   const hpPercentage = (char.hp / char.maxHp) * 100;


### PR DESCRIPTION
## Summary
- ensure heroes sort front-to-back by enabling `reverseHeroOrder`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b25d9e1f08332a3bb45737992dc9d